### PR TITLE
Middleware toggle

### DIFF
--- a/mockserver/mockserver/settings.py
+++ b/mockserver/mockserver/settings.py
@@ -194,3 +194,6 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 # CORS configuration
 
 CORS_ORIGIN_ALLOW_ALL = True
+
+# API Settings
+IS_ADMIN_API = os.getenv("IS_ADMIN_API", "false").lower() == "true"

--- a/mockserver/tenants/middlewares/tenant.py
+++ b/mockserver/tenants/middlewares/tenant.py
@@ -1,9 +1,15 @@
 from tenants.utils import organization_from_request
 
+from django.conf import settings
+from django.core.exceptions import MiddlewareNotUsed
+
 
 class TenantMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
+
+        if settings.IS_ADMIN_API:
+            raise MiddlewareNotUsed()
 
     def __call__(self, request):
         request.organization = organization_from_request(request)


### PR DESCRIPTION
This PR adds an environment flag to toggle usage of the API middlewares that discriminate based on URL

The rationale behind this is to allow the project to run two different APIs with reduced usage, for the sake of improving routing until the project is split into services