### PR TITLE
API Routing

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,17 +1,6 @@
-upstream mock_server {
-    server app:8000;
-}
-
 server {
     listen 80;
     server_name localhost;
-
-    location / {
-        proxy_pass http://mock_server;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_redirect off;
-    }
 
     location /static/ {
         alias /www/mockserver/static/;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,41 @@
 version: '3.4'
 
 services:
-  app:
+  admin_app:
+    image: ldelelis/mockserver:develop
+    restart: always
+    command: gunicorn -w4 -b 0.0.0.0:8000 --chdir ./mockserver mockserver.wsgi
+    environment:
+      - IS_ADMIN_API=true
+      - DATABASE_URL=postgres://mockserver:changeme@db:5432/mocks-api
+      - DEBUG=True
+    volumes:
+      - .:/www
+      - static_volume:/usr/src/app/mockserver/static
+    depends_on:
+      - db
+    labels:
+      traefik.enable: "true"
+      traefik.frontend.passHostHeaders: "true"
+      traefik.http.services.admin_app.loadbalancer.server.port: "8000"
+      traefik.http.routers.admin_app.rule: Host(`localhost`)
+
+  mocks_app:
     image: ldelelis/mockserver:develop
     restart: always
     command: gunicorn -w4 -b 0.0.0.0:8000 --chdir ./mockserver mockserver.wsgi
     environment:
       - DATABASE_URL=postgres://mockserver:changeme@db:5432/mocks-api
-      - DEBUG=False
+      - DEBUG=True
     volumes:
       - .:/www
-      - static_volume:/www/mockserver/static
     depends_on:
       - db
+    labels:
+      traefik.enable: "true"
+      traefik.frontend.passHostHeaders: "true"
+      traefik.http.services.mocks_app.loadbalancer.server.port: "8000"
+      traefik.http.routers.mocks_app.rule: HostRegexp(`{org:[a-zA-Z0-9]+}.{proj:[a-zA-Z]+}.localhost`)
 
   tasks:
     image: ldelelis/mockserver:develop
@@ -24,6 +47,18 @@ services:
     depends_on:
       - cache
 
+  traefik:
+    image: traefik:v2.0
+    restart: always
+    ports:
+      - "8000:80"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    command:
+      - "--providers.docker"
+    depends_on:
+      - admin_app
+      - mocks_app
 
   nginx:
     image: nginx:latest
@@ -31,10 +66,12 @@ services:
     volumes:
       - ./conf:/etc/nginx/conf.d
       - static_volume:/www/mockserver/static
-    ports:
-      - "8000:80"
     depends_on:
-      - app
+      - traefik
+    labels:
+      traefik.enable: "true"
+      traefik.frontend.passHostHeaders: "true"
+      traefik.http.routers.nginx.rule: Host(`localhost`) && PathPrefix(`/static`)
 
   db:
     image: postgres:12

--- a/mockserver/mockserver/urls.py
+++ b/mockserver/mockserver/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 from drf_yasg.views import get_schema_view
@@ -32,5 +33,9 @@ urlpatterns = [
     path('api/v1/', include('api.api_urls', namespace='v1')),
     path('openapi/', schema.with_ui('redoc', cache_timeout=0), name='openapi-schema'),
     path('', include('authentication.urls')),
-    path('', include('api.urls')),  # THIS MUST ALWAYS BE LAST
 ]
+
+if not settings.IS_ADMIN_API:
+    urlpatterns.append(
+        path('', include('api.urls'))
+    )


### PR DESCRIPTION
This PR deals with the concern of odd routing between mock fetch views, and authentication/resources endpoints

A Traefik controller was inserted to deal with multiple host endpoints, in order to avoid taxing either nginx or the API itself