### PR TITLE
HTTP Verb Primary Key

### DIFF
--- a/mockserver/mocks/migrations/0001_initial.py
+++ b/mockserver/mocks/migrations/0001_initial.py
@@ -81,9 +81,10 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='HttpVerb',
             fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('last_modified', models.DateTimeField(auto_now=True)),
-                ('name', models.CharField(max_length=255, primary_key=True, serialize=False)),
+                ('name', models.CharField(max_length=255, serialize=False)),
                 ('tenant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='tenants.Tenant')),
             ],
             options={

--- a/mockserver/mocks/models.py
+++ b/mockserver/mocks/models.py
@@ -177,7 +177,6 @@ class Header(DateAwareModel):
 class HttpVerb(DateAwareModel):
     name = models.CharField(
         max_length=255,
-        primary_key=True
     )
     organization = models.ForeignKey(
         'tenants.Organization',


### PR DESCRIPTION
Address the fact that HttpVerb does not use a surrogata value as primary key